### PR TITLE
Fixes for 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,12 @@
-# Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
 os:
-  - linux
   - osx
+  - linux
 julia:
-# - 0.7-beta
+  - 0.7
+  - "1.0"
   - nightly
 notifications:
   email: false
-# uncomment the following lines to override the default test script
-#script:
-#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - pwd
-#  - julia --depwarn=no -e 'import Pkg; Pkg.clone(pwd(),"CpuId"); Pkg.build("CpuId"); Pkg.test("CpuId"; coverage=true)'
 after_success:
-  # push coverage results to Coveralls
-  #- julia -e 'cd(Pkg.dir("CpuId")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
-  # push coverage results to Codecov
-  - julia --depwarn=no -e 'import Pkg; cd(Pkg.dir("CpuId")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'using Pkg; Pkg.dir("CpuId"); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,0 @@
-name = "CpuId"
-uuid = "2400aa70-7bc4-11e8-0d0f-6103d1925e2b"
-authors = ["Markus J. Weber"]
-version = "0.2.0"
-
-[deps]
-Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
   - julia_version: 0.7
-  - julia_version: "1.0"
+  - julia_version: 1.0
   - julia_version: nightly
 
 platform:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,18 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
-#  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-#  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: "1.0"
+  - julia_version: nightly
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+# Uncomment the following lines to allow failures on nightly julia
+# (tests will run but not make your overall status red)
+matrix:
+   allow_failures:
+   - julia_version: nightly
 
 branches:
   only:
@@ -17,20 +26,18 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - pwd
-  - C:\projects\julia\bin\julia --depwarn=no -e "import InteractiveUtils; versioninfo();
-      import Pkg; Pkg.clone(pwd(), \"CpuId\"); Pkg.build(\"CpuId\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia --depwarn=no -e "import Pkg; Pkg.test(\"CpuId\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# Uncomment to support code coverage upload. Should only be enabled for packages
+# which would have coverage gaps without running on Windows
+on_success:
+   - echo "%JL_CODECOV_SCRIPT%"
+   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/src/CpuId.jl
+++ b/src/CpuId.jl
@@ -105,12 +105,12 @@ function cpumodel() ::Dict{Symbol, UInt8}
     #  Ext.Model:  16:19
     #  Ext.Family: 20:27
     eax, ebx, ecx, edx = cpuid(0x01)
-    Dict( :Family    => UInt8((eax & 0x0000_0f00 >> 8)
-                             +(eax & 0x0ff0_0000 >> (20-4)))
-        , :Model     => UInt8((eax & 0x0000_00f0 >> 4)
-                             +(eax & 0x000f_0000 >> (16-4)))
+    Dict( :Family    => UInt8(((eax & 0x0000_0f00) >> 8)
+                             +((eax & 0x0ff0_0000) >> (20-4)))
+        , :Model     => UInt8(((eax & 0x0000_00f0) >> 4)
+                             +((eax & 0x000f_0000) >> (16-4)))
         , :Stepping  =>  UInt8(eax & 0x0000_000f)
-        , :CpuType   =>  UInt8(eax & 0x0000_3000 >> 12))
+        , :CpuType   =>  UInt8((eax & 0x0000_3000) >> 12))
 end
 
 
@@ -409,7 +409,7 @@ function cpuarchitecture() ::Symbol
     family == 0x6f && return :Bulldozer
     family == 0x7f && return (model == 0x30) ? :Puma : :Jaguar
     family == 0x8f && return :Zen
-    
+
     return :Unknown
 end
 
@@ -518,7 +518,7 @@ function cpucores() ::Int
     end
 
     return iszero(nc) ? # no cores detected? then maybe its AMD?
-        # AMD 
+        # AMD
         ((cpuid(0x8000_0008)[3] & 0x00ff)+1) :
         # Intel, we need nonzero values of nc and nl
         (iszero(nl) ? nc : nc ÷ nl)
@@ -617,7 +617,7 @@ function cputhreads() ::Int
     end
 
     return iszero(nc) ? # no cores detected? then maybe its AMD?
-        # AMD 
+        # AMD
         ((cpuid(0x0000_0001)[2] >> 16) & 0x00ff) :
         # Intel
         (nc)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -116,7 +116,7 @@ flush(stdout) ; flush(stderr)
                         @test getfield(CpuId, fns)() == res
                     end
                 end
-        
+
             end
         end)
 


### PR DESCRIPTION
This PR looks to upgrade CpuId.jl to 1.0
We have 
- cleaned up the travis and appveyor scripts
- fixed a deprecation call of `&` in `cpuid` not having parenthesis.
- tries to fix #30 