### PR TITLE
Added Project.toml and cacheinlusive.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.jl.mem
 *.swp
 Manifest.toml
+*~

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,16 @@
+name = "CpuId"
+uuid = "adafc99b-e345-5852-983c-f28acb93d879"
+authors = ["Markus J. Weber"]
+version = "0.2.3"
+
+[deps]
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[compat]
+julia = "1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,6 +45,10 @@ using Markdown: MD
     for i in 0:5
         @test isa( cachesize(i)       , Integer )
     end
+    @test isa( cacheinclusive()       , Tuple )
+    for i in 0:5
+        @test isa( cacheinclusive(i)  , Integer )
+    end
     @test isa( cpuarchitecture()      , Symbol )
     @test isa( cpubrand()             , String )
     @test isa( cpumodel()             , Dict )


### PR DESCRIPTION
`cacheinclusive` indicates whether each cache includes lower cachelevels.

When experimenting with block sizes for matrix multiplication, I realized my Cascadelake CPU (which has a non-inclusive L3) liked to use a much larger % of its L3 than my Haswell (with an inclusive L3). Then again, the Cascadelake also liked to use a larger percentage of its much larger L2 cache as well, and neither of them have inclusive L2 caches. 

Figured this would be generally useful for those using cache sizes.