### PR TITLE
add some explicit precompile statements for Julia v1.9 and newer

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,13 +5,14 @@ version = "0.3.1"
 
 [deps]
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [compat]
 julia = "1.7"
+PrecompileTools = "1.1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test"]
-

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CpuId"
 uuid = "adafc99b-e345-5852-983c-f28acb93d879"
 authors = ["Markus J. Weber"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"

--- a/src/CpuId.jl
+++ b/src/CpuId.jl
@@ -1087,6 +1087,12 @@ function cpuinfo()
 end
 
 
+# explicit precompilation only on Julia v1.9 and newer
+if VERSION >= v"1.9"
+    include("precompile.jl")
+end
+
+
 end # module CpuId
 
 #=--- end of file ---------------------------------------------------------=#

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,8 @@
+using PrecompileTools: @compile_workload
+
+@compile_workload begin
+    cacheinclusive()
+    cachelinesize()
+    cachesize()
+    cpucores()
+end


### PR DESCRIPTION
This fixes the remaining compilation time when using CPUSummary after https://github.com/JuliaSIMD/CPUSummary.jl/pull/21