### PR TITLE
add :i686 to Sys.ARCH check

### DIFF
--- a/src/CpuInstructions.jl
+++ b/src/CpuInstructions.jl
@@ -50,7 +50,7 @@ end
 #
 # Test Sys.ARCH for valid CPU architectures at compile time
 #
-@static if Sys.ARCH in (:x86, :x86_64)
+@static if Sys.ARCH in (:x86, :x86_64, :i686)
 
     # Low level cpuid call, taking eax=leaf and ecx=subleaf,
     # returning eax, ebx, ecx, edx as NTuple(4,UInt32)


### PR DESCRIPTION
Fixes #62 and possibly also #55 

Sys.ARCH returns `:i686` on 32-Bit Julia Systems, so i added that Symbol to the check.
Im not sure if there even is any Scenario at all, where Sys.ARCH returns `x86`.